### PR TITLE
Don't use absolute version number for skia dependency

### DIFF
--- a/www-client/ladybird/ladybird-9999.ebuild
+++ b/www-client/ladybird/ladybird-9999.ebuild
@@ -24,7 +24,7 @@ IUSE="clang"
 
 # how to version check skia on 9999?
 DEPEND="
-	=media-libs/skia-129-r2
+	>=media-libs/skia-129
 	media-libs/libjxl
 	media-libs/libwebp
 	media-libs/libavif


### PR DESCRIPTION
Currently, dependency resolution fails because in the last commit the version of skia was updated to 129-r3, but the ladybird ebuild still depends on 129-r2

To remove the unnecessary burden of continuously updating this version number in the `ladybird` dependencies, I propose that the dependency is changed from `=129-r2` to `>=129`