### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Repository contains Gentoo ebuilds for:
 
 If you want to contribute to Ladybird development
 
-This might help you doing so (set EGIT_LADYBIRD_REPO to your fork)
+This might help you doing so (set EGIT_REPO_URI in `www-client/ladybird/ladybird-9999.ebuild` to your fork)
 
 
 ##### Disclaimer


### PR DESCRIPTION
Is EGIT_<NAME>_REPO a special variable or an implicit reference to "EGIT_REPO_URI in the ladybird ebuild file"? If it's the latter I think it's nice to make it explicit.